### PR TITLE
Add client details

### DIFF
--- a/console-src/src/components/ClientForm/ClientForm.tsx
+++ b/console-src/src/components/ClientForm/ClientForm.tsx
@@ -182,7 +182,6 @@ class ClientForm extends Component<ClientFormProps, State> {
         <TextInput
           label={copy.clientForm.secret}
           placeholder={copy.clientForm.placeholders.secret}
-          type="password"
           value={secret}
           optional
           handleChange={this.handleTextInputChange("secret")}

--- a/console-src/src/components/ClientForm/ClientForm.tsx
+++ b/console-src/src/components/ClientForm/ClientForm.tsx
@@ -153,7 +153,9 @@ class ClientForm extends Component<ClientFormProps, State> {
       name,
       redirectUri,
       secret,
-      scopes: (Object.keys(scopes) as (keyof Scopes)[]).filter(scope => scopes[scope])
+      scopes: (Object.keys(scopes) as (keyof Scopes)[]).filter(
+        scope => scopes[scope]
+      )
     });
 
     this.props.history.push("/clients");
@@ -185,10 +187,10 @@ class ClientForm extends Component<ClientFormProps, State> {
           optional
           handleChange={this.handleTextInputChange("secret")}
         />
-        <CheckboxGroup title={copy.clientForm.scopes.title}>
-          {(Object.keys(scopes) as (keyof Scopes)[]).map((scope) => (
+        <CheckboxGroup title={copy.scopes.title}>
+          {(Object.keys(scopes) as (keyof Scopes)[]).map(scope => (
             <Checkbox
-              label={copy.clientForm.scopes[scope]}
+              label={copy.scopes[scope]}
               key={scope}
               checked={scopes[scope]}
               handleClick={this.handleCheckboxClick(scope)}

--- a/console-src/src/components/ClientItem/ClientItem.tsx
+++ b/console-src/src/components/ClientItem/ClientItem.tsx
@@ -1,0 +1,151 @@
+import React, { Component, Fragment } from "react";
+import styled from "styled-components";
+
+import { OAuthClient } from "../../types/oAuthClient";
+import { BodyText } from "../../components/Text";
+import { Scope } from "../../types/oAuthClient";
+import Checkbox from "../inputs/Checkbox";
+
+import colors from "../../theme/colors";
+import copy from "../../copy";
+
+const ClientItemContainer = styled.div`
+  cursor: pointer;
+  display: block;
+  padding: 1rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid ${colors.veryLightGrey};
+`;
+
+const ClientItemText = styled(BodyText)`
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const ClientItemUri = styled(ClientItemText)`
+  text-align: right;
+  padding-left: 1rem;
+`;
+
+const ClientDetailsItemContainer = styled.div`
+  padding-bottom: 0.5rem;
+`;
+
+type ClientDetailsItemProps = {
+  name: string;
+  value: string;
+};
+
+const ClientDetailsItem = ({ name, value }: ClientDetailsItemProps) => (
+  <ClientDetailsItemContainer>
+    <BodyText className="primary-black bold without-padding">{name}</BodyText>
+    <BodyText className="primary-black">{value}</BodyText>
+  </ClientDetailsItemContainer>
+);
+
+const ClientDetailsScopesContainer = styled.div``;
+
+type ClientDetailsScopesProps = {
+  title: string;
+  scopes: Scope[];
+};
+
+const ClientDetailsScopes = ({ scopes, title }: ClientDetailsScopesProps) => (
+  <ClientDetailsScopesContainer>
+    <BodyText className="primary-black bold">{title}</BodyText>
+    {scopes.map(scope => (
+      <Checkbox
+        // @ts-ignore
+        label={copy.scopes[scope]}
+        key={scope}
+        checked
+        disabled
+      />
+    ))}
+  </ClientDetailsScopesContainer>
+);
+
+const ClientDetails = styled.div`
+  padding: 1rem;
+  border-bottom: 1px solid ${colors.veryLightGrey}
+  display: flex;
+`;
+
+const ClientDetailsColumn = styled.div`
+  flex: 0 0 30%;
+
+  &.wide {
+    flex: 0 0 70%;
+  }
+`;
+
+type ClientItemProps = {
+  client: OAuthClient;
+};
+
+type ClientItemState = {
+  expanded: boolean;
+};
+
+class ClientItem extends Component<ClientItemProps, ClientItemState> {
+  constructor(props: ClientItemProps) {
+    super(props);
+
+    this.state = {
+      expanded: false
+    };
+  }
+
+  toggleDetails = () => {
+    this.setState(state => ({ expanded: !state.expanded }));
+  };
+
+  render() {
+    const { expanded } = this.state;
+    const { client } = this.props;
+
+    return (
+      <Fragment>
+        <ClientItemContainer onClick={this.toggleDetails}>
+          <ClientItemText className="without-padding primary-black">
+            {client.name}
+          </ClientItemText>
+          <ClientItemUri className="without-padding">
+            {client.redirectUri}
+          </ClientItemUri>
+        </ClientItemContainer>
+        {expanded && (
+          <ClientDetails>
+            <ClientDetailsColumn className="wide">
+              <ClientDetailsItem
+                name={copy.dashboard.clientDetails.id}
+                value={client.id}
+              />
+              <ClientDetailsItem
+                name={copy.dashboard.clientDetails.name}
+                value={client.name}
+              />
+              <ClientDetailsItem
+                name={copy.dashboard.clientDetails.redirectUri}
+                value={client.redirectUri}
+              />
+            </ClientDetailsColumn>
+            <ClientDetailsColumn>
+              <ClientDetailsScopes
+                scopes={client.scopes}
+                title={copy.scopes.title}
+              />
+            </ClientDetailsColumn>
+          </ClientDetails>
+        )}
+      </Fragment>
+    );
+  }
+}
+
+export default ClientItem;

--- a/console-src/src/components/ClientItem/ClientItem.tsx
+++ b/console-src/src/components/ClientItem/ClientItem.tsx
@@ -85,6 +85,14 @@ const ClientDetailsColumn = styled.div`
   &.wide {
     flex: 0 0 70%;
   }
+
+  @media (max-width: 800px) {
+    flex: 0 0 100%;
+
+    &.wide {
+      flex: 0 0 100%;
+    }
+  }
 `;
 
 const ClientDetailsActions = styled.div`
@@ -94,6 +102,16 @@ const ClientDetailsActions = styled.div`
 
   & > *:first-child {
     margin-right: 1rem;
+  }
+
+  @media (max-width: 800px) {
+    flex-direction: column;
+    margin-top: 1rem;
+
+    & > *:first-child {
+      margin-right: 0;
+      margin-bottom: 0.5rem;
+    }
   }
 `;
 

--- a/console-src/src/components/ClientItem/ClientItem.tsx
+++ b/console-src/src/components/ClientItem/ClientItem.tsx
@@ -81,6 +81,7 @@ const ClientDetails = styled.div`
 
 const ClientDetailsColumn = styled.div`
   flex: 0 0 30%;
+  padding-bottom: 1rem;
 
   &.wide {
     flex: 0 0 70%;
@@ -88,6 +89,7 @@ const ClientDetailsColumn = styled.div`
 
   @media (max-width: 800px) {
     flex: 0 0 100%;
+    padding-bottom: 0;
 
     &.wide {
       flex: 0 0 100%;

--- a/console-src/src/components/ClientItem/ClientItem.tsx
+++ b/console-src/src/components/ClientItem/ClientItem.tsx
@@ -5,6 +5,8 @@ import { OAuthClient } from "../../types/oAuthClient";
 import { BodyText } from "../../components/Text";
 import { Scope } from "../../types/oAuthClient";
 import Checkbox from "../inputs/Checkbox";
+import Button from "../buttons/Button";
+import LinkButton from "../buttons/LinkButton";
 
 import colors from "../../theme/colors";
 import copy from "../../copy";
@@ -74,6 +76,7 @@ const ClientDetails = styled.div`
   padding: 1rem;
   border-bottom: 1px solid ${colors.veryLightGrey}
   display: flex;
+  flex-wrap: wrap;
 `;
 
 const ClientDetailsColumn = styled.div`
@@ -81,6 +84,16 @@ const ClientDetailsColumn = styled.div`
 
   &.wide {
     flex: 0 0 70%;
+  }
+`;
+
+const ClientDetailsActions = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+
+  & > *:first-child {
+    margin-right: 1rem;
   }
 `;
 
@@ -103,6 +116,10 @@ class ClientItem extends Component<ClientItemProps, ClientItemState> {
 
   toggleDetails = () => {
     this.setState(state => ({ expanded: !state.expanded }));
+  };
+
+  showDeletionConfirmation = () => {
+    // TODO: show a modal to confirm client deletion
   };
 
   render() {
@@ -141,6 +158,14 @@ class ClientItem extends Component<ClientItemProps, ClientItemState> {
                 title={copy.scopes.title}
               />
             </ClientDetailsColumn>
+            <ClientDetailsActions>
+              <LinkButton to={`/clients/update/${client.id}`}>
+                {copy.dashboard.clientDetails.updateClientLabel}
+              </LinkButton>
+              <Button onClick={this.showDeletionConfirmation} destructive>
+                {copy.dashboard.clientDetails.deleteClientLabel}
+              </Button>
+            </ClientDetailsActions>
           </ClientDetails>
         )}
       </Fragment>

--- a/console-src/src/components/ClientItem/index.tsx
+++ b/console-src/src/components/ClientItem/index.tsx
@@ -1,0 +1,3 @@
+import ClientItem from "./ClientItem";
+
+export default ClientItem;

--- a/console-src/src/components/ClientList/ClientList.tsx
+++ b/console-src/src/components/ClientList/ClientList.tsx
@@ -1,56 +1,14 @@
 import React from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
 
 import { BodyText } from "../../components/Text";
 import TitledCard from "../../components/TitledCard";
+import ClientItem from "../../components/ClientItem";
 import { OAuthClient } from "../../types/oAuthClient";
-import colors from "../../theme/colors";
 import copy from "../../copy";
 
 type ClientListProps = {
   clients: OAuthClient[];
-};
-
-type ClientItemProps = {
-  client: OAuthClient;
-};
-
-const ClientItemContainer = styled(Link)`
-  display: block;
-  padding: 1rem;
-  height: 2rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: 1px solid ${colors.veryLightGrey};
-`;
-
-const ClientItemText = styled(BodyText)`
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-const ClientItemUri = styled(ClientItemText)`
-  text-align: right;
-  padding-left: 1rem;
-`;
-
-const ClientItem = (props: ClientItemProps) => {
-  const { client } = props;
-
-  return (
-    <ClientItemContainer to={`/clients/${props.client.id}`}>
-      <ClientItemText className="without-padding primary-black">
-        {client.name}
-      </ClientItemText>
-      <ClientItemUri className="without-padding">
-        {client.redirectUri}
-      </ClientItemUri>
-    </ClientItemContainer>
-  );
 };
 
 const TitleContainer = styled.div`

--- a/console-src/src/components/buttons/Button/Button.tsx
+++ b/console-src/src/components/buttons/Button/Button.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from "react";
 import styled from "styled-components";
+import classnames from "classnames";
 
 import colors from "../../../theme/colors";
 
@@ -32,6 +33,10 @@ const Button = styled.button`
   position: relative;
   z-index: 1;
 
+  &.destructive {
+    background-color: ${colors.darkRed};
+  }
+
   &:hover:not([disabled]) {
     background-color: ${colors.black};
   }
@@ -47,6 +52,7 @@ interface Props {
   children: ReactNode;
   disabled?: boolean;
   loading?: boolean;
+  destructive?: boolean;
   type?: "button" | "submit";
 }
 
@@ -55,9 +61,17 @@ const ButtonComponent = ({
   disabled,
   loading,
   onClick,
+  destructive,
   type = "submit"
 }: Props) => (
-  <Button type={type} disabled={disabled || loading} onClick={onClick}>
+  <Button
+    type={type}
+    disabled={disabled || loading}
+    onClick={onClick}
+    className={classnames({
+      destructive
+    })}
+  >
     {loading && (
       <LoadingContainer>
         <LoadingIndicator small white />

--- a/console-src/src/components/inputs/Checkbox/Checkbox.tsx
+++ b/console-src/src/components/inputs/Checkbox/Checkbox.tsx
@@ -40,12 +40,15 @@ const Container = styled.div`
 type Props = {
   checked: boolean;
   label: string;
-  handleClick: (event: React.MouseEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  handleClick?: (event: React.MouseEvent<HTMLInputElement>) => void;
 };
 
-const Checkbox = ({ checked, handleClick, label }: Props) => {
+const noop = () => {};
+
+const Checkbox = ({ checked, handleClick, label, disabled }: Props) => {
   return (
-    <Container onClick={handleClick}>
+    <Container onClick={disabled ? noop : handleClick}>
       <CheckboxIcon className={checked ? "" : "empty"} />
       <StyledLabel className={checked ? "" : "empty"}>{label}</StyledLabel>
     </Container>

--- a/console-src/src/copy/index.ts
+++ b/console-src/src/copy/index.ts
@@ -14,7 +14,9 @@ export default {
     clientDetails: {
       id: "Client ID",
       name: "Name",
-      redirectUri: "Redirect URI"
+      redirectUri: "Redirect URI",
+      updateClientLabel: "Update client",
+      deleteClientLabel: "Delete client"
     }
   },
   createClient: {

--- a/console-src/src/copy/index.ts
+++ b/console-src/src/copy/index.ts
@@ -10,6 +10,11 @@ export default {
       emptyListText: "You don't have any existing clients yet.",
       nameTitle: "Client name",
       uriTitle: "Redirect URI"
+    },
+    clientDetails: {
+      id: "Client ID",
+      name: "Name",
+      redirectUri: "Redirect URI"
     }
   },
   createClient: {
@@ -25,17 +30,17 @@ export default {
       name: "Client name",
       redirectUri: "https://redirect.uri/callback",
       secret: "Secret"
-    },
-    scopes: {
-      OFFLINE: "Offline",
-      ACCOUNTS: "Accounts",
-      USERS: "Users",
-      TRANSACTIONS: "Transactions",
-      TRANSFERS: "Transfers",
-      SUBSCRIPTIONS: "Subscriptions",
-      STATEMENTS: "Statements",
-      title: "Scopes"
     }
+  },
+  scopes: {
+    OFFLINE: "Offline",
+    ACCOUNTS: "Accounts",
+    USERS: "Users",
+    TRANSACTIONS: "Transactions",
+    TRANSFERS: "Transfers",
+    SUBSCRIPTIONS: "Subscriptions",
+    STATEMENTS: "Statements",
+    title: "Scopes"
   },
   backButtonLabel: "Back"
 };


### PR DESCRIPTION
This PR adds some components to show client details on click in the user dashboard.

After this, only will remain:
* client deletion confirmation through a dialog box (mutation also needs to be written)
* client update page needs to be stitched together reusing client creation components (should be pretty fast)

I wanted to add a transition when user opens the details but really didn't have the time, looks like this so far:
<img width="718" alt="Screenshot 2019-10-24 at 18 13 15" src="https://user-images.githubusercontent.com/3253522/67504908-8cd1f300-f68a-11e9-8ce8-b0fe5f5a6455.png">

and for small device:
<img width="381" alt="Screenshot 2019-10-25 at 09 48 36" src="https://user-images.githubusercontent.com/3253522/67553073-aa47a100-f70c-11e9-83fc-26223081bcd5.png">

