### PR TITLE
Add client updates

### DIFF
--- a/console-src/src/App.tsx
+++ b/console-src/src/App.tsx
@@ -10,6 +10,7 @@ import KontistClientProvider from "./enhancers/KontistClientProvider";
 import AuthenticateUser from "./enhancers/AuthenticateUser";
 import Dashboard from "./pages/Dashboard";
 import CreateClient from "./pages/CreateClient";
+import UpdateClient from "./pages/UpdateClient";
 
 const history = createBrowserHistory();
 
@@ -25,6 +26,11 @@ const App = () => (
               <Route path="/" exact component={Dashboard} />
               <Route path="/clients" exact component={Dashboard} />
               <Route path="/clients/create" exact component={CreateClient} />
+              <Route
+                path="/clients/update/:clientId"
+                exact
+                component={UpdateClient}
+              />
             </Switch>
           </OAuthClientsProvider>
         </AuthenticateUser>

--- a/console-src/src/components/ClientItem/ClientItem.tsx
+++ b/console-src/src/components/ClientItem/ClientItem.tsx
@@ -62,13 +62,7 @@ const ClientDetailsScopes = ({ scopes, title }: ClientDetailsScopesProps) => (
   <ClientDetailsScopesContainer>
     <BodyText className="primary-black bold">{title}</BodyText>
     {scopes.map(scope => (
-      <Checkbox
-        // @ts-ignore
-        label={copy.scopes[scope]}
-        key={scope}
-        checked
-        disabled
-      />
+      <Checkbox label={copy.scopes[scope]} key={scope} checked disabled />
     ))}
   </ClientDetailsScopesContainer>
 );

--- a/console-src/src/components/Text/index.tsx
+++ b/console-src/src/components/Text/index.tsx
@@ -23,6 +23,10 @@ const BodyText = styled.p`
     font-size: 18px;
   }
 
+  &.x-small {
+    font-size: 16px;
+  }
+
   &.italic {
     font-style: italic;
   }

--- a/console-src/src/copy/index.ts
+++ b/console-src/src/copy/index.ts
@@ -23,6 +23,12 @@ export default {
     title: "Create client",
     buttonLabel: "Create client"
   },
+  updateClient: {
+    title: "Update client",
+    buttonLabel: "Update client",
+    secretInformation:
+      "Submitting a secret with the update will override the existing secret"
+  },
   clientForm: {
     name: "Name",
     redirectUri: "Redirect URI",

--- a/console-src/src/pages/UpdateClient/UpdateClient.tsx
+++ b/console-src/src/pages/UpdateClient/UpdateClient.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { History } from "history";
+
+import withOAuthClients from "../../enhancers/withOAuthClients";
+import Layout from "../../layout";
+import ActionBar from "../../components/ActionBar";
+import BackButton from "../../components/buttons/BackButton";
+import { BodyText } from "../../components/Text";
+import TitledCard from "../../components/TitledCard";
+import ClientForm from "../../components/ClientForm";
+
+import copy from "../../copy";
+import { OAuthClient } from "../../types/oAuthClient";
+
+type Props = {
+  oAuthClients: OAuthClient[];
+  updateClient: Function;
+  isLoading: boolean;
+  history: History;
+  match: {
+    params: {
+      clientId: string;
+    };
+  };
+};
+
+const UpdateClient = ({
+  oAuthClients,
+  updateClient,
+  isLoading,
+  history,
+  match
+}: Props) => {
+  const { clientId } = match.params;
+  const client = oAuthClients.find(client => client.id === clientId);
+
+  return (
+    <Layout>
+      <ActionBar>
+        <BackButton onClick={() => history.goBack()} />
+        <BodyText className="without-padding primary-black">
+          {copy.backButtonLabel}
+        </BodyText>
+      </ActionBar>
+      <TitledCard
+        renderTitle={() => (
+          <BodyText className="without-padding primary-black bold">
+            {copy.updateClient.title}
+          </BodyText>
+        )}
+      >
+        <ClientForm
+          client={client}
+          action={updateClient}
+          buttonLabel={copy.updateClient.buttonLabel}
+          isLoading={isLoading}
+          history={history}
+        />
+      </TitledCard>
+    </Layout>
+  );
+};
+
+export default withOAuthClients(UpdateClient);

--- a/console-src/src/pages/UpdateClient/index.tsx
+++ b/console-src/src/pages/UpdateClient/index.tsx
@@ -1,0 +1,3 @@
+import UpdateClient from "./UpdateClient";
+
+export default UpdateClient;

--- a/console-src/src/queries/index.tsx
+++ b/console-src/src/queries/index.tsx
@@ -38,7 +38,33 @@ export const createClientMutation = `
   }
 `;
 
-export const updateClientMutation = ``;
+export const updateClientMutation = `
+  mutation(
+    $id: String!,
+    $name: String,
+    $redirectUri: String,
+    $secret: String,
+    $scopes: [ScopeType!],
+    $grantTypes: [GrantType!]
+  ) {
+    updateClient(
+      client: {
+        id: $id
+        name: $name
+        redirectUri: $redirectUri
+        grantTypes: $grantTypes
+        scopes: $scopes
+        secret: $secret
+      }
+    ) {
+      id
+      redirectUri
+      name
+      grantTypes
+      scopes
+    }
+  }
+`;
 
 export const deleteClientMutation = `
   mutation(

--- a/console-src/src/types/oAuthClient.tsx
+++ b/console-src/src/types/oAuthClient.tsx
@@ -31,6 +31,7 @@ export type CreateOAuthClientPayload = {
 export type UpdateOAuthClientPayload = {
   id: string;
   name?: string;
+  secret?: string;
   redirectUri?: string;
   scopes?: Scope[];
   grantTypes?: GrantType[];


### PR DESCRIPTION
In this PR we are adding the functionality to update clients.

It should be the last of the main PRs for the API console app.

When user clicks on update for an existing client we bring him to the same form as for `create client` but with fields already pre-filled with existing values for the client.

I am not very satisfied with the way we are handling secrets currently. If a client has an existing secret, there is currently no way to update to a null secret 🤔We could maybe add a specific "I want to update my secret" toggle and only then show the field for secret, which if `null` would update the secret to null 🤔 it seems a bit convoluted to me also. Any better ideas?

Same as before, to test you can: `cd console-src && yarn && yarn start` then go to `http://localhost:3000` (or whatever port the dev server will run on)

Here are some screenshots: 
<img width="689" alt="Screenshot 2019-10-25 at 13 57 25" src="https://user-images.githubusercontent.com/3253522/67569572-877ab400-f72f-11e9-8dbd-e9fd256c7fc5.png">

<img width="361" alt="Screenshot 2019-10-25 at 13 57 51" src="https://user-images.githubusercontent.com/3253522/67569583-8b0e3b00-f72f-11e9-9d72-d2429df4814c.png">

