### PR TITLE
Update production redirect_uri

### DIFF
--- a/console-src/src/config.js
+++ b/console-src/src/config.js
@@ -2,5 +2,5 @@ module.exports = {
   appDirectory: "console",
   baseAPIUrl: "https://api.kontist.com",
   clientId: "fe8055d9-f496-49e9-9551-5b416139630e",
-  redirectUri: "https://kontist.dev/console"
+  redirectUri: "https://kontist.dev/console/"
 };


### PR DESCRIPTION
A slash `/` is appended to any url when viewing the`index` page for our github pages deployed site, didn't notice it as it doesn't happen locally.

We need to update the redirect_uri for the production config.

We will also need to update it in our prod db