### PR TITLE
Reset old tabs after new login

### DIFF
--- a/playground/playground.html
+++ b/playground/playground.html
@@ -569,11 +569,19 @@ permalink: /playground/
       const root = document.getElementById("root");
       root.classList.add("playgroundIn");
 
-      GraphQLPlayground.init(root, {
+      const graphQLServerConfig = {
         endpoint: `https://api.kontist.com/api/graphql`,
         headers: {
           Authorization: `Bearer ${accessToken}`
         }
+      };
+
+      GraphQLPlayground.init(root, {
+        ...graphQLServerConfig,
+        tabs: [
+          // Explicitly pass empty tab for GraphQL Playground to reset all previous tabs with old headers
+          graphQLServerConfig
+        ]
       });
     };
 


### PR DESCRIPTION
We have a problem when after login your old tabs are preserved, but they have stale auth header. As a result, you can open them but all requests fail.

I checked the source code of GraphQL Playground, and unfortunately, there is no way to update headers of old tabs. It always creates a new tab when you pass new headers: https://github.com/prisma-labs/graphql-playground/blob/a220dc00b7bb0fa3c35f13b8691c66be8ef49a82/packages/graphql-playground-react/src/state/sessions/reducers.ts#L451-L481

As an alternative solution, my fix makes GraphQL Playground always start with one empty tab with the new auth header. As a result, the user won't be able to use old tabs with stale auth header after a new login.

https://app.zenhub.com/workspaces/kontist-engineering-5be06ab44b5806bc2bf14eca/issues/figureaps/figure-backend/5764