### PR TITLE
Remove obsolete ts-ignore comments

### DIFF
--- a/console-src/src/enhancers/withOAuthClients.tsx
+++ b/console-src/src/enhancers/withOAuthClients.tsx
@@ -60,8 +60,6 @@ class OAuthClientsProvider extends Component<Props, State> {
 
     this.setState({
       isLoading: false,
-      // Currently rawQuery return type does not include clients
-      // @ts-ignore
       oAuthClients: viewer.clients
     });
   };
@@ -72,8 +70,6 @@ class OAuthClientsProvider extends Component<Props, State> {
     });
 
     const {
-      // Currently rawQuery return type does not include client mutation results
-      // @ts-ignore
       createClient: client
     } = await this.props.kontistClient.graphQL.rawQuery(createClientMutation, {
       ...payload,
@@ -101,8 +97,6 @@ class OAuthClientsProvider extends Component<Props, State> {
     }
 
     const {
-      // Currently rawQuery return type does not include client mutation results
-      // @ts-ignore
       updateClient: updatedClient
     } = await this.props.kontistClient.graphQL.rawQuery(updateClientMutation, {
       ...updatePayload,


### PR DESCRIPTION
These comments were added during development when our SDK didn't have types for OAuth2 clients yet.

The types have now been properly updated, let's remove these legacy comments